### PR TITLE
Allow some syscalls needed by numpy

### DIFF
--- a/SYSCALLS.md
+++ b/SYSCALLS.md
@@ -200,10 +200,6 @@ See [link](#link)
 Listen for a connection on a socket. Could be used to run a webserver from
 within the enclave, possibly spoofing sentinel.
 
-### mbind
-
-Set the NUMA policy, requires CAP_SYS_NICE for certain flags.
-
 ### migrate_pages
 
 Move all pages in another process to another set of nodes. I'm suspicious of
@@ -307,26 +303,6 @@ Reboot the system.
 ### request_key
 
 Request a key from the kernel's key management facility.
-
-### sched_setaffinity
-
-User code probably shouldn't be making changes to process scheduling.
-
-### sched_setattr
-
-See [sched_setaffinity](#sched_setaffinity)
-
-### sched_setparam
-
-See [sched_setaffinity](#sched_setaffinity)
-
-### sched_setscheduler
-
-See [sched_setaffinity](#sched_setaffinity)
-
-### sched_yield
-
-See [sched_setaffinity](#sched_setaffinity)
 
 ### seccomp
 

--- a/env.c
+++ b/env.c
@@ -32,6 +32,8 @@ char **cape_envp_new(uid_t uid) {
      * the entire array. Because of this, memset will also not work here, and
      * to be completely standards compliant, we must NULL out this array in a
      * for loop.
+     *
+     * See: https://c-faq.com/null/runtime0.html
      */
     for (size_t i = 0; i < num_environment_variables + 1; i++) {
         envp[i] = NULL;

--- a/privileges.h
+++ b/privileges.h
@@ -1,6 +1,9 @@
 #ifndef PRIVILEGES_H
 #define PRIVILEGES_H
 
+#include <stdbool.h>
+#include <sys/types.h>
+
 /*
  * - Set the UID of the current process to `uid`.
  * - Drop group memberships to only the current user group.

--- a/seccomp.c
+++ b/seccomp.c
@@ -577,6 +577,11 @@ static const int ALLOWED_SYSCALLS[] = {
     SCMP_SYS(madvise),
 
     /*
+     * Set NUMA policy, used by numpy
+     */
+    SCMP_SYS(mbind),
+
+    /*
      * Issue memory barriers on a set of threads
      */
     SCMP_SYS(membarrier),
@@ -983,6 +988,7 @@ static const int ALLOWED_SYSCALLS[] = {
     SCMP_SYS(sched_get_priority_min),
     SCMP_SYS(sched_getscheduler),
     SCMP_SYS(sched_rr_get_interval),
+    SCMP_SYS(sched_yield),
 
     /*
      * Monitor multiple file descriptors.


### PR DESCRIPTION
Numpy at times needs `mbind` and `sched_yield`, which are safe syscalls to make.